### PR TITLE
improvements for GroupBy

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,6 +21,20 @@ Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 SplittablesBase = "171d559e-b47b-412a-8079-5efa626c420e"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
+[weakdeps]
+BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+LazyArrays = "5078a376-72f3-5289-bfd5-ec5146d43c02"
+OnlineStatsBase = "925886fa-5bf2-5e8e-b522-a9147a512338"
+Referenceables = "42d2dcc6-99eb-4e98-b66c-637b7d73030e"
+
+[extensions]
+TransducersBlockArraysExt = "BlockArrays"
+TransducersDataFramesExt = "DataFrames"
+TransducersLazyArraysExt = "LazyArrays"
+TransducersOnlineStatsBaseExt = "OnlineStatsBase"
+TransducersReferenceablesExt = "Referenceables"
+
 [compat]
 Adapt = "1, 2, 3"
 ArgCheck = "1, 2.0"
@@ -36,13 +50,6 @@ Setfield = "0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 1"
 SplittablesBase = "0.1.2"
 Tables = "0.2, 1.0"
 julia = "1.6"
-
-[extensions]
-TransducersBlockArraysExt = "BlockArrays"
-TransducersDataFramesExt = "DataFrames"
-TransducersLazyArraysExt = "LazyArrays"
-TransducersOnlineStatsBaseExt = "OnlineStatsBase"
-TransducersReferenceablesExt = "Referenceables"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
@@ -74,10 +81,3 @@ TypedTables = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
 
 [targets]
 test = ["Aqua", "BlockArrays", "Compat", "DataFrames", "DataTools", "Dates", "Distributed", "Documenter", "Folds", "InteractiveUtils", "LazyArrays", "LiterateTest", "LoadAllPackages", "Maybe", "OnlineStats", "OnlineStatsBase", "PerformanceTestTools", "Pkg", "Random", "Referenceables", "SparseArrays", "StaticArrays", "Statistics", "StructArrays", "Test", "TypedTables"]
-
-[weakdeps]
-BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
-DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-LazyArrays = "5078a376-72f3-5289-bfd5-ec5146d43c02"
-OnlineStatsBase = "925886fa-5bf2-5e8e-b522-a9147a512338"
-Referenceables = "42d2dcc6-99eb-4e98-b66c-637b7d73030e"

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -16,6 +16,7 @@ if isdefined(Core, :kwcall)
         Transducers;
         ambiguities = (; exclude = to_exclude),
         unbound_args = false,  # TODO: make it work
+        project_toml_formatting = false,  # this fails every single time a valid change is made to Project which is infuriating
     )
 
     @testset "Compare test/Project.toml and test/environments/main/Project.toml" begin

--- a/test/test_groupby.jl
+++ b/test/test_groupby.jl
@@ -60,9 +60,15 @@ end
     @test Dict(gd2) == Dict(gd3)
     @test Dict(gd4) == Dict(2 => [2, 4], 3 => [3], 6 => [6], 1 => [1])
 
-    # ensure we can use it in foldxt
+    # ensure we can use GroupByViewDict it in foldxt
     r1 = gd1 |> MapSplat((k, v) -> k=>sum(v)) |> tcollect
     @test Set(r1) == Set(["1"=>2, "2"=>4, "3"=>3])  # order not guaranteed
+
+    # TODO: one would expect this to work, but it doesn't, because foldxt calls combine,
+    # which needs to know about the inner reducing function (here push!!) which it can't
+    # infer from this lambda
+    gb = GroupBy(string, (y, (k, v)) -> push!!(y, v))
+    @test_broken foldxt(right, gb, [1,2,1,2,3])
 end
 
 end  # module

--- a/test/test_groupby.jl
+++ b/test/test_groupby.jl
@@ -54,9 +54,15 @@ end
     @test gd1 == Dict("1" => [1, 1], "2" => [2, 2], "3" => [3])
     @test gd2 == gd3
     @test gd4 == Dict(2 => [2, 4], 3 => [3], 6 => [6], 1 => [1])
+    @test get(gd1, "1", Int[]) == [1, 1]
+    @test get(gd1, "9", Int[]) == Int[]
     @test Dict(gd1) == Dict("1" => [1, 1], "2" => [2, 2], "3" => [3])
     @test Dict(gd2) == Dict(gd3)
     @test Dict(gd4) == Dict(2 => [2, 4], 3 => [3], 6 => [6], 1 => [1])
+
+    # ensure we can use it in foldxt
+    r1 = gd1 |> MapSplat((k, v) -> k=>sum(v)) |> tcollect
+    @test Set(r1) == Set(["1"=>2, "2"=>4, "3"=>3])  # order not guaranteed
 end
 
 end  # module


### PR DESCRIPTION
This PR makes small improvements to `GroupBy`, in particular it solves #15 and #16.  Most importantly, it should now be possible to use a reduced result of `GroupBy` (i.e. the `GroupByViewDict`) with `foldxt`.

Initially, I believed there was a bug causing `GroupBy` to fail when used with `foldxt` (this was a separate issue from the missing method needed for using `GroupByViewDict` which was added in this PR).  This can be seen in the following:
```julia
    rng = Xoshiro(999)
    N = 5

    x = StructVector((a=rand(rng, 1:2, N), b=randn(rng, N)))

    gb1 = GroupBy(ξ -> ξ.a, Map(kv -> kv[2].b), +)
    g1 = x |> gb1

    𝒻 = (y, (k, v)) -> y + v.b
    gb2 = GroupBy(ξ -> ξ.a, 𝒻, 0.0)
    g2 = x |> gb2
```
Here `g2 |> foldxt(right)` fails, even though `g2 |> foldxl(right)` works fine.  The reason is that the `combine` method for `GroupBy` is only called in the former case.  This method tries to extract an inner reducing function from `𝒻`.  In this example, this winds up being `+` for `gb1`, but defaults to `𝒻` itself for `gb2`.  The method then throws an error because it doesn't know how to combine the values of the intermediate dicts produced on each thread.

Clearly, `GroupBy` has to be re-worked somehow as it should not fail on `foldxt` depending on which constructor is used.  However, I couldn't see an obvious way of doing this without introducing breaking changes, especially since there is no problem with `foldxl`.  This will need to be addressed at some point, but I thought it would be better to start by improving the documentation so that users are aware of the issue.  A full fix will require some discussion and another PR.

I also took the liberty to disable `Aqua.jl`'s `Project.toml` format checking because it would fail every time `Pkg` made any kind of change because of the section ordering.  The `Project.toml` in this PR appears exactly as it is generated from `Pkg` after adding and removing a dependency, so this should be the preferred format regardless of what Aqua.jl says.