### PR TITLE
improve GroupBy documentation and remove some more old julia version support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Transducers"
 uuid = "28d57a85-8fef-5791-bfe6-a80928e7c999"
 authors = ["Takafumi Arakaki <aka.tkf@gmail.com>"]
-version = "0.4.78"
+version = "0.4.79"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Transducers.jl
+++ b/src/Transducers.jl
@@ -85,7 +85,7 @@ import Setfield
 import Tables
 using ArgCheck
 using BangBang.Experimental: modify!!, mergewith!!
-using BangBang.NoBang: SingletonVector
+using BangBang.NoBang: SingletonVector, SingletonDict
 using BangBang:
     @!, BangBang, Empty, append!!, collector, empty!!, finish!, push!!, setindex!!, union!!
 using Baselet

--- a/src/basics.jl
+++ b/src/basics.jl
@@ -11,22 +11,10 @@ julia> _unzip(((1, 2, 3), (4, 5, 6)))
 """
 _unzip(xs::Tuple{Vararg{NTuple{N,Any}}}) where {N} = ntuple(i -> map(x -> x[i], xs), N)
 
-if isdefined(Iterators, :Zip1)  # VERSION < v"1.1-"
-    arguments(xs::Iterators.Zip1) = (xs.a,)
-    arguments(xs::Iterators.Zip2) = (xs.a, xs.b)
-    arguments(xs::Iterators.Zip) = (xs.a, arguments(xs.z)...)
-    const _Zip = Iterators.AbstractZipIterator
-else
-    arguments(xs::Iterators.Zip) = xs.is
-    const _Zip = Iterators.Zip
-end
+arguments(xs::Iterators.Zip) = xs.is
+const _Zip = Iterators.Zip
 
-if VERSION < v"1.3"
-    _Channel(f, ::Type{T}, size; kwargs...) where {T} =
-        Channel(f; ctype = T, csize = size, kwargs...)
-else
-    _Channel(f, ::Type{T}, size; kwargs...) where {T} = Channel{T}(f, size; kwargs...)
-end
+_Channel(f, ::Type{T}, size; kwargs...) where {T} = Channel{T}(f, size; kwargs...)
 
 _typeof(::Type{T}) where {T} = Type{T}
 _typeof(::T) where {T} = T
@@ -55,13 +43,6 @@ prefixed_type_name(@nospecialize x) =
 
 const DenseSubVector{T} =
     SubArray{T, 1, Vector{T}, Tuple{UnitRange{Int}}, true}
-
-# https://github.com/JuliaLang/julia/pull/33533
-if VERSION < v"1.4"
-    const PartitionableArray = Vector
-else
-    const PartitionableArray = AbstractArray
-end
 
 
 const _non_executable_transducer_msg = """

--- a/src/core.jl
+++ b/src/core.jl
@@ -251,9 +251,7 @@ AbstractFilter
 
 abstract type AbstractReduction{innertype} <: Function end
 
-if VERSION >= v"1.3"  # post https://github.com/JuliaLang/julia/pull/31916
-    @inline (rf::AbstractReduction)(state, input) = next(rf, state, input)
-end
+@inline (rf::AbstractReduction)(state, input) = next(rf, state, input)
 
 InnerType(::Type{<:AbstractReduction{T}}) where T = T
 
@@ -320,10 +318,6 @@ struct Reduction{X <: Transducer, I} <: AbstractReduction{I}
 end
 
 Base.:(==)(r1::Reduction, r2::Reduction) = (r1.xform == r2.xform) && (r1.inner == r2.inner)
-
-if VERSION < v"1.3"  # pre https://github.com/JuliaLang/julia/pull/31916
-    @inline (rf::Reduction)(state, input) = next(rf, state, input)
-end
 
 prependxf(rf::AbstractReduction, xf) = Reduction(xf, rf)
 setinner(rf::Reduction, inner) = Reduction(xform(rf), inner)
@@ -393,11 +387,7 @@ Composition of transducers.
 @inline Base.:∘(f::IdentityTransducer, ::IdentityTransducer) = f
 @inline Base.:∘(::IdentityTransducer, f::Composition) = f  # disambiguation
 
-if VERSION >= v"1.3"
-    (xf::Transducer)(itr) = eduction(xf, itr)
-else
-    Base.:|>(itr, xf::Transducer) = eduction(xf, itr)
-end
+(xf::Transducer)(itr) = eduction(xf, itr)
 
 """
     ReducingFunctionTransform(xf)

--- a/src/groupby.jl
+++ b/src/groupby.jl
@@ -64,7 +64,7 @@ julia> inner = Map(last) ⨟ Map() do ξ
            SingletonDict(ξ.b => ξ.c)
        end;
 
-julai> x |> GroupBy(ξ -> ξ.a, inner, merge!!) |> foldxl(right)
+julia> x |> GroupBy(ξ -> ξ.a, inner, merge!!) |> foldxl(right)
 Transducers.GroupByViewDict{String,Dict{Int64, Int64},…}(...):
   "B" => Dict(2=>2)
   "A" => Dict(3=>3, 1=>1)

--- a/src/groupby.jl
+++ b/src/groupby.jl
@@ -58,6 +58,8 @@ Transducers.GroupByViewDict{Bool,Int64,…}(...):
 ```jldoctest; setup = :(using Transducers)
 julia> using Transducers: SingletonDict;
 
+julia> using BangBang; # for merge!!
+
 julia> x = [(a="A", b=1, c=1), (a="B", b=2, c=2), (a="A", b=3, c=3)];
 
 julia> inner = Map(last) ⨟ Map() do ξ

--- a/src/groupby.jl
+++ b/src/groupby.jl
@@ -48,7 +48,7 @@ See also `groupreduce` in
 [SplitApplyCombine.jl](https://github.com/JuliaData/SplitApplyCombine.jl).
 
 # Examples
-```jldoctest
+```jldoctest; setup = :(using Transducers)
 julia> [1,2,3,4] |> GroupBy(iseven, Map(last)'(+)) |> foldxl(right)
 Transducers.GroupByViewDict{Bool,Int64,…}(...):
   0 => 4

--- a/src/library.jl
+++ b/src/library.jl
@@ -353,10 +353,6 @@ OfType(T::Type) = OfType{T}()
 @inline _next_oftype(T, inner, result, input) =
     input isa T ? next(inner, result, input) : result
 
-# Workaround StackOverflowError in Julia 1.0
-# https://travis-ci.com/JuliaFolds/Transducers.jl/jobs/171732596
-if VERSION >= v"1.1-"
-
 @inline _next_oftype(T, inner, result, input::Tuple) =
     _next_oftype_t(T, inner, result, (), input...)
 
@@ -394,8 +390,6 @@ end
 end
 # Not using `Base.tail(input)` for a Tuple-of-(possibly)-Union seems
 # to be a nice strategy for achieving type-stability.
-
-end  # if
 
 # https://clojure.github.io/clojure/clojure.core-api.html#clojure.core/take
 # https://clojuredocs.org/clojure.core/take

--- a/src/partitionby.jl
+++ b/src/partitionby.jl
@@ -180,6 +180,3 @@ end
 
 (f::PartitionBy)(xs::AbstractArray) = array_partitionby(f.f, xs)
 
-if VERSION < v"1.3"
-    Base.:|>(xs::AbstractArray, f::PartitionBy) = array_partitionby(f.f, xs)
-end

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -120,13 +120,6 @@ function transduce_assoc(
     return result
 end
 
-if VERSION >= v"1.3-alpha"
-    maybe_collect(coll) = coll
-else
-    maybe_collect(coll::AbstractArray) = coll
-    maybe_collect(coll) = collect(coll)
-end
-
 function _transduce_assoc_nocomplete(
     rf::F,
     init,
@@ -134,7 +127,7 @@ function _transduce_assoc_nocomplete(
     basesize,
     ctx::DACContext = NoopDACContext(),
 ) where {F}
-    reducible = SizedReducible(maybe_collect(coll), basesize)
+    reducible = SizedReducible(coll, basesize)
     return _reduce(ctx, rf, init, reducible)
 end
 
@@ -224,7 +217,7 @@ _might_return_reduced(rf, init, coll) =
     ) !== Union{}
 
 _reduce_dummy(rf, init, coll) =
-    __reduce_dummy(rf, init, SizedReducible(maybe_collect(coll), 1))
+    __reduce_dummy(rf, init, SizedReducible(coll, 1))
 
 function __reduce_dummy(rf, init, reducible)
     if issmall(reducible)
@@ -378,7 +371,7 @@ tcopy(xf, T::Type{<:AbstractSet}, reducible; kwargs...) =
 function tcopy(
     ::typeof(Map(identity)),
     T::Type{<:AbstractSet},
-    array::PartitionableArray;
+    array::AbstractArray;
     basesize::Integer = max(1, length(array) ÷ Threads.nthreads()),
     kwargs...,
 )

--- a/src/unordered.jl
+++ b/src/unordered.jl
@@ -38,12 +38,6 @@ function _unsafe_sync_end(tasks)
     end
 end
 
-if VERSION < v"1.5-"
-    const sync_end = Base.sync_end
-else
-    const sync_end = _unsafe_sync_end
-end
-
 function transduce_commutative!(
     xform::Transducer,
     step,
@@ -85,7 +79,7 @@ function transduce_commutative!(
             rethrow()
         end
     end
-    sync_end(tasks)
+    _unsafe_sync_end(tasks)
     return foldl(combine_step(rf), Map(fetch), tasks)
 end
 

--- a/test/threads/test_parallel_reduce.jl
+++ b/test/threads/test_parallel_reduce.jl
@@ -110,16 +110,16 @@ end
 
 @testset "tcopy(Set, ...)" begin
     @testset for xs in [[1], [1, 1], [1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1, 1]]
-        @test tcopy(Set, xs::Transducers.PartitionableArray) == Set([1])
+        @test tcopy(Set, xs::AbstractArray) == Set([1])
         @testset for basesize in 1:3
-            @test tcopy(Set, xs::Transducers.PartitionableArray, basesize = basesize) ==
+            @test tcopy(Set, xs::AbstractArray, basesize = basesize) ==
                 Set([1])
         end
     end
     @testset "empty" begin
-        @test tcopy(Set, Int[]::Transducers.PartitionableArray) === Empty(Set)
+        @test tcopy(Set, Int[]) === Empty(Set)
         @testset for basesize in 1:3
-            @test tcopy(Set, Int[]::Transducers.PartitionableArray, basesize = basesize) ==
+            @test tcopy(Set, Int[], basesize = basesize) ==
                 Empty(Set)
         end
     end


### PR DESCRIPTION
This is mostly (yet another) re-organization of the doc string for `GroupBy` which emphasizes usage that applies correctly to `foldxt` as well as `foldxl`.

I have also removed some Julia `VERSION` checks for versions prior to the current LTS (1.6).  (Apparently I missed some on my last round.)

Lastly, I now have imported `BangBang.NoBang.SingletonDict` (but *not* re-exported it).  I've come to believe `BangBang` probably ought to be re-exported from `Transducers`, however for the time being this is one of the functions from that package that is crucial in some (reasonably common) use cases and I am now using that function in a doc string.