### PR TITLE
Make `Cat()` support `asfoldable` 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Transducers"
 uuid = "28d57a85-8fef-5791-bfe6-a80928e7c999"
 authors = ["Takafumi Arakaki <aka.tkf@gmail.com>"]
-version = "0.4.79"
+version = "0.4.80"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/library.jl
+++ b/src/library.jl
@@ -153,7 +153,7 @@ struct Cat <: Transducer
 end
 
 @inline function next(rf::R_{Cat}, acc, x)
-    rf0, itr0 = retransform(inner(rf), x)
+    rf0, itr0 = retransform(inner(rf), asfoldable(x))
     return foldl_nocomplete(rf0, acc, itr0)
 end
 

--- a/test/__test_ir.jl
+++ b/test/__test_ir.jl
@@ -36,8 +36,13 @@ const __width_ir_fmul = __is32bit ? 2 : 4
         # compiler becomes _extremely_ smart).
         ir = llvm_ir(map!, (xf, ys, xs))
         @debug "map!/history" LLVM_IR=Text(ir)
-        @test_broken nmatches(r"fmul <[0-9]+ x double>", ir) >= __width_ir_fmul
-        @test_broken nmatches(r"fcmp [a-z]* <[0-9]+ x double>", ir) >= __width_ir_fmul
+        if VERSION < v"1.11.0-"
+            @test_broken nmatches(r"fmul <[0-9]+ x double>", ir) >= __width_ir_fmul
+            @test_broken nmatches(r"fcmp [a-z]* <[0-9]+ x double>", ir) >= __width_ir_fmul
+        else
+            @test nmatches(r"fmul <[0-9]+ x double>", ir) >= __width_ir_fmul
+            @test nmatches(r"fcmp [a-z]* <[0-9]+ x double>", ir) >= __width_ir_fmul
+        end
     end
 
     @testset for simd in [false, true, :ivdep]

--- a/test/__test_ir.jl
+++ b/test/__test_ir.jl
@@ -40,6 +40,7 @@ const __width_ir_fmul = __is32bit ? 2 : 4
             @test_broken nmatches(r"fmul <[0-9]+ x double>", ir) >= __width_ir_fmul
             @test_broken nmatches(r"fcmp [a-z]* <[0-9]+ x double>", ir) >= __width_ir_fmul
         else
+            # Compiler is now "_extremely_ smart"
             @test nmatches(r"fmul <[0-9]+ x double>", ir) >= __width_ir_fmul
             @test nmatches(r"fcmp [a-z]* <[0-9]+ x double>", ir) >= __width_ir_fmul
         end

--- a/test/test_inference.jl
+++ b/test/test_inference.jl
@@ -59,6 +59,7 @@ end
             @test_broken_inferred foldl(*, opcompose(Scan(+), Scan(+)), xs; init=1)
             @test_broken_inferred foldl(*, opcompose(Scan(+), Map(x -> x::Int), Scan(+)), xs)
         else
+            # Looks like inference has improved here
             @test_inferred foldl(right, opcompose(Scan(+), Scan(+)), xs)
             @test_inferred foldl(*, opcompose(Scan(+), Scan(+)), xs)
             @test_inferred foldl(*, opcompose(Scan(+), Scan(+)), xs; init=1)

--- a/test/test_inference.jl
+++ b/test/test_inference.jl
@@ -53,10 +53,17 @@ end
         # Nested stateful transducers.  (The ones with `right` and
         # `Map(x -> x::Int)` actually succeeded in some REPL
         # sessions...  Maybe some caching problem?)
-        @test_broken_inferred foldl(right, opcompose(Scan(+), Scan(+)), xs)
-        @test_broken_inferred foldl(*, opcompose(Scan(+), Scan(+)), xs)
-        @test_broken_inferred foldl(*, opcompose(Scan(+), Scan(+)), xs; init=1)
-        @test_broken_inferred foldl(*, opcompose(Scan(+), Map(x -> x::Int), Scan(+)), xs)
+        if VERSION < v"1.11.0-"
+            @test_broken_inferred foldl(right, opcompose(Scan(+), Scan(+)), xs)
+            @test_broken_inferred foldl(*, opcompose(Scan(+), Scan(+)), xs)
+            @test_broken_inferred foldl(*, opcompose(Scan(+), Scan(+)), xs; init=1)
+            @test_broken_inferred foldl(*, opcompose(Scan(+), Map(x -> x::Int), Scan(+)), xs)
+        else
+            @test_inferred foldl(right, opcompose(Scan(+), Scan(+)), xs)
+            @test_inferred foldl(*, opcompose(Scan(+), Scan(+)), xs)
+            @test_inferred foldl(*, opcompose(Scan(+), Scan(+)), xs; init=1)
+            @test_inferred foldl(*, opcompose(Scan(+), Map(x -> x::Int), Scan(+)), xs)
+        end
     end
     @test_inferred foldl(+, Cat(), [[1]])
 

--- a/test/test_processes.jl
+++ b/test/test_processes.jl
@@ -172,7 +172,12 @@ end
     @testset "inference" begin
         @test (@inferred setinput(ed, [0])).coll isa Vector{Int}
         @test (@inferred setinput(ed, view([0], 1:1))).coll isa SubArray{Int}
-        @test_broken (@inferred setinput(ed, Float64[])).coll isa Vector{Float64}
+        if VERSION < v"1.11.0-"
+            # Looks like inference improved
+            @test_broken (@inferred setinput(ed, Float64[])).coll isa Vector{Float64}
+        else
+            @test (@inferred setinput(ed, Float64[])).coll isa Vector{Float64}
+        end
     end
 end
 

--- a/test/threads/test_examples_tutorial_parallel.jl
+++ b/test/threads/test_examples_tutorial_parallel.jl
@@ -5,7 +5,13 @@ using LiterateTest.AssertAsTest: @assert
 # * https://travis-ci.com/JuliaFolds/Transducers.jl/jobs/270458293
 # * https://github.com/JuliaLang/julia/commit/961907977a57ae7b72ddb374e63341f3633a0f0a
 if VERSION >= v"1.2"
-    include("../../examples/tutorial_parallel.jl")
+    if VERSION < v"1.11-"
+        # There's a bug in early versions of v.1.11 that cause this to segfault due to try-catch blocks getting elided
+        # Should be fixed in https://github.com/JuliaLang/julia/pull/51853 
+        include("../../examples/tutorial_parallel.jl")
+    else
+        @warn "Skipping tests on ../../examples/tutorial_parallel.jl due to a bug.\nPlease check and see if https://github.com/JuliaLang/julia/pull/51853 resolves this issue once it merges."
+    end
 end
 
 end  # module


### PR DESCRIPTION
This should fix https://github.com/JuliaFolds2/Transducers.jl/issues/23, though I suspect there may be other places where issues like this lurk. 

@alecloudenback please do let me know if you encounter more things like this. 