### PR TITLE
Fix tcollect of ProgressLoggingFoldable

### DIFF
--- a/src/Transducers.jl
+++ b/src/Transducers.jl
@@ -138,7 +138,6 @@ include("simd.jl")
 include("executors.jl")
 include("processes.jl")
 include("threading_utils.jl")
-include("reduce.jl")
 include("nondeterministic_threading.jl")
 include("dreduce.jl")
 include("unordered.jl")
@@ -147,6 +146,7 @@ include("lister.jl")
 include("show.jl")
 include("comprehensions.jl")
 include("progress.jl")
+include("reduce.jl")
 
 #used by TransducersOnlineStatsBaseExt, but exported directly in tests
 const OSNonZeroNObsError = ArgumentError(

--- a/src/progress.jl
+++ b/src/progress.jl
@@ -60,6 +60,7 @@ end
 Base.IteratorSize(::Type{ProgressLoggingFoldable{T}}) where {T} = Base.IteratorSize(T)
 Base.IteratorEltype(::Type{ProgressLoggingFoldable{T}}) where {T} = Base.IteratorEltype(T)
 Base.length(foldable::ProgressLoggingFoldable) = length(foldable.foldable)
+Base.size(foldable::ProgressLoggingFoldable) = size(foldable.foldable)
 Base.eltype(::Type{ProgressLoggingFoldable{T}}) where {T} = eltype(T)
 
 # Use Juno/Atom-compatible log-level.  See:

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -353,6 +353,10 @@ function split_into_chunks(coll, sz)
     collect(Iterators.partition(coll, sz))
 end
 
+function split_into_chunks(coll::Transducers.ProgressLoggingFoldable, sz)
+    withprogress(collect(Iterators.partition(coll.foldable, sz)); interval=coll.interval)
+end
+
 tcopy(xf, reducible; kwargs...) = tcopy(xf, _materializer(reducible), reducible; kwargs...)
 
 function tcopy(::Type{T}, itr; kwargs...) where {T}


### PR DESCRIPTION
Hello,

I have been carrying this patch to Transducers in my dev-ed version of Transducers for months now, but never found the time to submit a PR. This PR fixes #10 and allows one to define transducers wrapped with withprogress to use progress loggers. This is very nice, as it allows one to use the built-in support for ProgressLogging.jl in Pluto and VS Code together with Transducers and Folds.

For example
```julia
using Logging: global_logger
using TerminalLoggers: TerminalLogger
using Transducers

global_logger(TerminalLogger())

julia> tcollect(data |> withprogress |> Map() do (y, x); y+x end)
Progress: 100%|██████████████████████████████████████████████████████████████████████████| Time: 0:00:00
9-element Vector{Int64}:
 3
 4
 5
 4
 5
 6
 5
 6
 7

```

